### PR TITLE
Fix : Fat Jar 적용해 build.gradle 과 McJarSwap.jar 업데이트

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,17 +28,16 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
 application {
 	mainClass = 'McJarSwap.McJarSwapApplication'
 }
+
+bootJar {
+	archiveFileName = 'McJarSwap.jar' // 원하는 파일명 설정
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 jar {
-	duplicatesStrategy = DuplicatesStrategy.INCLUDE
-	manifest {
-		attributes(
-				'Main-Class': 'McJarSwap.McJarSwapApplication'
-		)
-	}
-	from {
-		configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-	}
+	enabled = false // 일반 JAR 파일 생성을 비활성화 (Spring Boot는 bootJar 사용)
 }


### PR DESCRIPTION
### Fat Jar 적용
- Fat JAR 생성을 강제함으로써, libs/McJarSwap.jar을 backend에 포함시켜 업데이트함
- 로컬과 Ubuntu 서버에서 Jar 실행시 Spring 서버가 자동으로 꺼지는 문제 해결